### PR TITLE
fix #7: return the real 64-bit address of a Cellular device

### DIFF
--- a/XBeeLibrary.Core/CellularDevice.cs
+++ b/XBeeLibrary.Core/CellularDevice.cs
@@ -80,20 +80,6 @@ namespace XBeeLibrary.Core
 		public XBeeIMEIAddress IMEIAddress { get; private set; }
 
 		/// <summary>
-		/// The 64-bit address of this XBee device. This is not supported in Cellular 
-		/// devices, so it always returns <c>null</c>.
-		/// </summary>
-		/// <seealso cref="XBee64BitAddress"/>
-		public override XBee64BitAddress XBee64BitAddr
-		{
-			get
-			{
-				// Cellular protocol does not have 64-bit address.
-				return null;
-			}
-		}
-
-		/// <summary>
 		/// The node identifier of this XBee device. This is not supported in Cellular 
 		/// devices, so it always returns <c>null</c>.
 		/// </summary>


### PR DESCRIPTION
The module IMEI is obtained from the SH and SL parameters, which are stored
in the XBee64BitAddr property. If the CellularDevice class overrides the
property and returns null, the IMEI cannot be initialized.

Signed-off-by: Ruben Moral <ruben.moral@digi.com>