### PR TITLE
hardware: add new versions to the supported hardware list

### DIFF
--- a/XBeeLibrary.Core/Models/HardwareVersionEnum.cs
+++ b/XBeeLibrary.Core/Models/HardwareVersionEnum.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright 2019, Digi International Inc.
+ * Copyright 2019-2021, Digi International Inc.
  * Copyright 2014, 2015, Sébastien Rault.
  * 
  * Permission to use, copy, modify, and/or distribute this software for any
@@ -94,7 +94,13 @@ namespace XBeeLibrary.Core.Models
 		CELLULAR_3_LTE_M_VERIZON = 0x4A,  // Abandoned
 		CELLULAR_3_LTE_M_ATT = 0x4B,
 		CELLULAR_3_LTE_M_ATT_TELIT = 0x4C,  // Never released
-		CELLULAR_3_CAT1_LTE_VERIZON = 0x4D
+		CELLULAR_3_CAT1_LTE_VERIZON = 0x4D,
+		CELLULAR_3_LTE_M_TELIT = 0x4E,
+		XBEE3_DM_LR = 0x50,
+		XBEE3_DM_LR_868 = 0x51,
+		XBEE3_RR = 0x52,
+		S2C_P5 = 0x53,
+		CELLULAR_3_CAT1_GLOBAL = 0x54
 	}
 
 	public static class HardwareVersionEnumExtensions
@@ -172,6 +178,12 @@ namespace XBeeLibrary.Core.Models
 			lookupTable.Add(HardwareVersionEnum.CELLULAR_3_LTE_M_ATT, "XBee3 Cellular LTE-M AT&T (u-blox)");
 			lookupTable.Add(HardwareVersionEnum.CELLULAR_3_LTE_M_ATT_TELIT, "XBee3 Cellular LTE-M AT&T (Telit)");
 			lookupTable.Add(HardwareVersionEnum.CELLULAR_3_CAT1_LTE_VERIZON, "XBee3 Cellular Cat 1 LTE Verizon");
+			lookupTable.Add(HardwareVersionEnum.CELLULAR_3_LTE_M_TELIT, "XBee 3 Cellular LTE - M / NB - IoT (Telit)");
+			lookupTable.Add(HardwareVersionEnum.XBEE3_DM_LR, "XB3-DMLR");
+			lookupTable.Add(HardwareVersionEnum.XBEE3_DM_LR_868, "XB3-DMLR868");
+			lookupTable.Add(HardwareVersionEnum.XBEE3_RR, "XBee 3 Reduced RAM");
+			lookupTable.Add(HardwareVersionEnum.S2C_P5, "S2C P5");
+			lookupTable.Add(HardwareVersionEnum.CELLULAR_3_CAT1_GLOBAL, "XBee Cellular 3 Cat 1 Global");
 		}
 
 		/// <summary>

--- a/XBeeLibrary.Core/Models/XBeeProtocol.cs
+++ b/XBeeLibrary.Core/Models/XBeeProtocol.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright 2019, Digi International Inc.
+ * Copyright 2019-2021, Digi International Inc.
  * Copyright 2014, 2015, Sébastien Rault.
  * 
  * Permission to use, copy, modify, and/or distribute this software for any
@@ -267,13 +267,16 @@ namespace XBeeLibrary.Core.Models
 				|| hardwareVersion.Value == HardwareVersionEnum.CELLULAR_3_LTE_M_VERIZON.GetValue()
 				|| hardwareVersion.Value == HardwareVersionEnum.CELLULAR_3_LTE_M_ATT.GetValue()
 				|| hardwareVersion.Value == HardwareVersionEnum.CELLULAR_3_LTE_M_ATT_TELIT.GetValue()
-				|| hardwareVersion.Value == HardwareVersionEnum.CELLULAR_3_CAT1_LTE_VERIZON.GetValue())
+				|| hardwareVersion.Value == HardwareVersionEnum.CELLULAR_3_CAT1_LTE_VERIZON.GetValue()
+				|| hardwareVersion.Value == HardwareVersionEnum.CELLULAR_3_LTE_M_TELIT.GetValue()
+				|| hardwareVersion.Value == HardwareVersionEnum.CELLULAR_3_CAT1_GLOBAL.GetValue())
 			{
 				return XBeeProtocol.CELLULAR;
 			}
 			else if (hardwareVersion.Value == HardwareVersionEnum.XBEE3_MICRO.GetValue()
 				|| hardwareVersion.Value == HardwareVersionEnum.XBEE3_TH.GetValue()
-				|| hardwareVersion.Value == HardwareVersionEnum.XBEE3_RESERVED.GetValue())
+				|| hardwareVersion.Value == HardwareVersionEnum.XBEE3_RESERVED.GetValue()
+				|| hardwareVersion.Value == HardwareVersionEnum.XBEE3_RR.GetValue())
 			{
 				if (firmwareVersion.StartsWith("2"))
 					return XBeeProtocol.RAW_802_15_4;
@@ -284,6 +287,15 @@ namespace XBeeLibrary.Core.Models
 			else if (hardwareVersion.Value == HardwareVersionEnum.XB8X.GetValue())
 			{
 				return XBeeProtocol.DIGI_MESH;
+			}
+			else if (hardwareVersion.Value == HardwareVersionEnum.XBEE3_DM_LR.GetValue()
+				|| hardwareVersion.Value == HardwareVersionEnum.XBEE3_DM_LR_868.GetValue())
+			{
+				return XBeeProtocol.DIGI_MESH;
+			}
+			else if (hardwareVersion.Value == HardwareVersionEnum.S2C_P5.GetValue())
+			{
+				return XBeeProtocol.ZIGBEE;
 			}
 
 			return XBeeProtocol.ZIGBEE;


### PR DESCRIPTION
- 0x4E: XBee 3 Cellular LTE-M/NB-IoT (Telit)
- 0x50: XB3-DMLR
- 0x51: XB3-DMLR868
- 0x52: XBee 3 Reduced RAM
- 0x53: S2C P5

https://onedigi.atlassian.net/browse/XBJAPI-535

Signed-off-by: Diego Escalona <diego.escalona@digi.com>