### PR TITLE
hardware: add new versions to the supported hardware list

### DIFF
--- a/XBeeLibrary.Core/Models/HardwareVersionEnum.cs
+++ b/XBeeLibrary.Core/Models/HardwareVersionEnum.cs
@@ -101,7 +101,9 @@ namespace XBeeLibrary.Core.Models
 		XBEE3_RR = 0x52,
 		S2C_P5 = 0x53,
 		CELLULAR_3_CAT1_GLOBAL = 0x54,
-		CELLULAR_3_CAT1_NA = 0x55
+		CELLULAR_3_CAT1_NA = 0x55,
+		CELLULAR_3_LTE_M_LOW_POWER = 0x56,
+		XBEE_RR_TH = 0x57
 	}
 
 	public static class HardwareVersionEnumExtensions
@@ -186,6 +188,8 @@ namespace XBeeLibrary.Core.Models
 			lookupTable.Add(HardwareVersionEnum.S2C_P5, "S2C P5");
 			lookupTable.Add(HardwareVersionEnum.CELLULAR_3_CAT1_GLOBAL, "XBee 3 Cellular Cat 1 Global");
 			lookupTable.Add(HardwareVersionEnum.CELLULAR_3_CAT1_NA, "XBee 3 Cellular Cat 1 North America");
+			lookupTable.Add(HardwareVersionEnum.CELLULAR_3_LTE_M_LOW_POWER, "XBee 3 Cellular LTE-M/NB-IoT Low Power");
+			lookupTable.Add(HardwareVersionEnum.XBEE_RR_TH, "XBee RR TH Pro/Non-Pro");
 		}
 
 		/// <summary>

--- a/XBeeLibrary.Core/Models/XBeeProtocol.cs
+++ b/XBeeLibrary.Core/Models/XBeeProtocol.cs
@@ -270,14 +270,16 @@ namespace XBeeLibrary.Core.Models
 				|| hardwareVersion.Value == HardwareVersionEnum.CELLULAR_3_CAT1_LTE_VERIZON.GetValue()
 				|| hardwareVersion.Value == HardwareVersionEnum.CELLULAR_3_LTE_M_TELIT.GetValue()
 				|| hardwareVersion.Value == HardwareVersionEnum.CELLULAR_3_CAT1_GLOBAL.GetValue()
-				|| hardwareVersion.Value == HardwareVersionEnum.CELLULAR_3_CAT1_NA.GetValue())
+				|| hardwareVersion.Value == HardwareVersionEnum.CELLULAR_3_CAT1_NA.GetValue()
+				|| hardwareVersion.Value == HardwareVersionEnum.CELLULAR_3_LTE_M_LOW_POWER.GetValue())
 			{
 				return XBeeProtocol.CELLULAR;
 			}
 			else if (hardwareVersion.Value == HardwareVersionEnum.XBEE3_MICRO.GetValue()
 				|| hardwareVersion.Value == HardwareVersionEnum.XBEE3_TH.GetValue()
 				|| hardwareVersion.Value == HardwareVersionEnum.XBEE3_RESERVED.GetValue()
-				|| hardwareVersion.Value == HardwareVersionEnum.XBEE3_RR.GetValue())
+				|| hardwareVersion.Value == HardwareVersionEnum.XBEE3_RR.GetValue()
+				|| hardwareVersion.Value == HardwareVersionEnum.XBEE_RR_TH.GetValue())
 			{
 				if (firmwareVersion.StartsWith("2"))
 					return XBeeProtocol.RAW_802_15_4;


### PR DESCRIPTION
- 0x56: XBee 3 Cellular LTE-M/NB-IoT Low Power
- 0x57: XBee RR TH Pro/Non-Pro

https://onedigi.atlassian.net/browse/XCTUAPP-298
https://onedigi.atlassian.net/browse/XCTUAPP-299

Signed-off-by: Diego Escalona <diego.escalona@digi.com>